### PR TITLE
I hate JSONs

### DIFF
--- a/controllers/buy.cpp
+++ b/controllers/buy.cpp
@@ -116,7 +116,7 @@ namespace controllers::post
             {"status", "sold"},
             {"transaction", {
                 {"id", to_string(gen_uuid())},
-                {"user_id", data["id"]},
+                {"user_id", data["id"].get<string>()},
                 {"price", post[4]},
             }}
         };

--- a/controllers/post.cpp
+++ b/controllers/post.cpp
@@ -52,11 +52,11 @@ namespace controllers::post
         }
 
         const string uuid = to_string(gen_uuid());
-        const string user_id = to_string(data["id"]);
-        const string title = to_string(body["title"]);
-        const string description = to_string(body["description"]);
-        const string price = to_string(body["price"]);
-        const string type = body["type"];
+        const string user_id = data["id"].get<string>();
+        const string title = body["title"].get<string>();
+        const string description = body["description"].get<string>();
+        const string price = body["price"].get<string>();
+        const string type = body["type"].get<string>();
         const string status = "active";
 
         const auto result = database::client::query(

--- a/controllers/post.cpp
+++ b/controllers/post.cpp
@@ -52,10 +52,10 @@ namespace controllers::post
         }
 
         const string uuid = to_string(gen_uuid());
-        const string user_id = data["id"];
-        const string title = body["title"];
-        const string description = body["description"];
-        const string price = body["price"];
+        const string user_id = to_string(data["id"]);
+        const string title = to_string(body["title"]);
+        const string description = to_string(body["description"]);
+        const string price = to_string(body["price"]);
         const string type = body["type"];
         const string status = "active";
 


### PR DESCRIPTION
This pull request includes changes to the `controllers` namespace to ensure proper type handling for JSON data. The most important changes involve modifying how data is retrieved from JSON objects to explicitly convert them to strings.

Type handling improvements:

* [`controllers/buy.cpp`](diffhunk://#diff-cf9287878f0cf276f0b2e8b18c0949abe751aa42269f88b9b5b55fcf051ec8e6L119-R119): Changed the retrieval of `user_id` from `data["id"]` to `data["id"].get<string>()` to ensure proper type conversion.
* [`controllers/post.cpp`](diffhunk://#diff-3aed1db56883460f31ad9365dcdec9149bd7f84882116e6d0329186ba960c9d9L55-R59): Updated the retrieval of multiple fields (`user_id`, `title`, `description`, `price`, `type`) from JSON objects to use the `.get<string>()` method for explicit type conversion.