### PR TITLE
Add error handling for database queries in post management functions

### DIFF
--- a/controllers/post.cpp
+++ b/controllers/post.cpp
@@ -59,10 +59,20 @@ namespace controllers::post
         const string type = body["type"];
         const string status = "active";
 
-        const auto result = database::client::query(
-            "INSERT INTO posts (id, user_id, title, description, price, type, status) VALUES ($1, $2, $3, $4, $5, $6, $7);",
-            {uuid, user_id, title, description, price, type, status}
-        );
+        try
+        {
+            const auto result = database::client::query(
+                "INSERT INTO posts (id, user_id, title, description, price, type, status) VALUES ($1, $2, $3, $4, $5, $6, $7);",
+                {uuid, user_id, title, description, price, type, status}
+            );
+        }
+        catch (const std::exception& e)
+        {
+            res.result(http::status::internal_server_error);
+            res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+            res.prepare_payload();
+            return res;
+        }
 
         nlohmann::json response;
         response["message"] = "Post created successfully";
@@ -84,10 +94,21 @@ namespace controllers::post
     http::response<http::string_body> find(http::request<http::string_body> const& req,
                                            http::response<http::string_body>& res)
     {
-        const auto posts = database::client::query(
-            "SELECT * FROM posts WHERE status = 'active' ORDER BY random() LIMIT 10;",
-            {}
-        );
+        vector<vector<string>> posts;
+        try
+        {
+            posts = database::client::query(
+                "SELECT * FROM posts WHERE status = 'active' ORDER BY random() LIMIT 10;",
+                {}
+            );
+        }
+        catch (const std::exception& e)
+        {
+            res.result(http::status::internal_server_error);
+            res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+            res.prepare_payload();
+            return res;
+        }
 
         if (posts.empty())
         {
@@ -136,7 +157,19 @@ namespace controllers::post
             return res;
         }
 
-        const auto post = database::client::query("SELECT * FROM posts WHERE id = $1;", {to_string(uuid)})[0];
+        vector<vector<string>> post;
+        try
+        {
+            post = database::client::query("SELECT * FROM posts WHERE id = $1;", {to_string(uuid)});
+        }
+        catch (const std::exception& e)
+        {
+            res.result(http::status::internal_server_error);
+            res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+            res.prepare_payload();
+            return res;
+        }
+
         if (post.empty())
         {
             res.result(http::status::not_found);
@@ -157,10 +190,22 @@ namespace controllers::post
 
         if (response["type"] == "sale")
         {
-            const auto transactions = database::client::query(
-                "SELECT * FROM transactions WHERE post_id = $1;",
-                {post_id}
-            );
+            vector<vector<string>> transactions;
+            try
+            {
+                transactions = database::client::query(
+                    "SELECT * FROM transactions WHERE post_id = $1;",
+                    {post_id}
+                );
+            }
+            catch (const std::exception& e)
+            {
+                res.result(http::status::internal_server_error);
+                res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+                res.prepare_payload();
+                return res;
+            }
+
             if (transactions.empty())
                 response["transaction"] = nlohmann::json();
             else
@@ -172,10 +217,22 @@ namespace controllers::post
         }
         else
         {
-            const auto bids = database::client::query(
-                "SELECT * FROM bids WHERE post_id = $1 ORDER BY price DESC;",
-                {post_id}
-            );
+            vector<vector<string>> bids;
+            try
+            {
+                bids = database::client::query(
+                    "SELECT * FROM bids WHERE post_id = $1 ORDER BY price DESC;",
+                    {post_id}
+                );
+            }
+            catch (const std::exception& e)
+            {
+                res.result(http::status::internal_server_error);
+                res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+                res.prepare_payload();
+                return res;
+            }
+
             response["bids"] = nlohmann::json::array();
             for (const auto& bid : bids)
                 response["bids"].push_back({
@@ -247,10 +304,20 @@ namespace controllers::post
         const string price = body["price"];
         const string type = body["type"];
 
-        const auto result = database::client::query(
-            "UPDATE posts SET title = $1, description = $2, price = $3, type = $4 WHERE id = $5 AND user_id = $6;",
-            {title, description, price, type, to_string(uuid), user_id}
-        );
+        try
+        {
+            const auto result = database::client::query(
+                "UPDATE posts SET title = $1, description = $2, price = $3, type = $4 WHERE id = $5 AND user_id = $6;",
+                {title, description, price, type, to_string(uuid), user_id}
+            );
+        }
+        catch (const std::exception& e)
+        {
+            res.result(http::status::internal_server_error);
+            res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+            res.prepare_payload();
+            return res;
+        }
 
         nlohmann::json response;
         response["message"] = "Post updated successfully";
@@ -300,10 +367,20 @@ namespace controllers::post
             return res;
         }
 
-        const auto result = database::client::query(
-            "UPDATE posts SET status = 'inactive' WHERE id = $1 AND user_id = $2;",
-            {to_string(uuid), data["id"]}
-        );
+        try
+        {
+            const auto result = database::client::query(
+                "UPDATE posts SET status = 'inactive' WHERE id = $1 AND user_id = $2;",
+                {to_string(uuid), data["id"]}
+            );
+        }
+        catch (const std::exception& e)
+        {
+            res.result(http::status::internal_server_error);
+            res.body() = R"({"message": "Database error: )" + string(e.what()) + R"("})";
+            res.prepare_payload();
+            return res;
+        }
 
         nlohmann::json response;
         response["message"] = "Post deleted successfully";


### PR DESCRIPTION
This pull request adds error handling for database operations in the `controllers/post.cpp` file. The changes ensure that any database exceptions are caught and appropriate error messages are returned to the client.

Error handling improvements:

* Wrapped the post creation query in a try-catch block to handle database exceptions and return an internal server error with a detailed message (`controllers/post.cpp`).
* Added error handling for the post retrieval query to catch exceptions and return an internal server error with a detailed message (`controllers/post.cpp`).
* Implemented error handling for the post detail query to catch exceptions and return an internal server error with a detailed message (`controllers/post.cpp`).
* Added try-catch blocks around the queries for retrieving transactions and bids related to a post, ensuring exceptions are caught and appropriate error messages are returned (`controllers/post.cpp`). [[1]](diffhunk://#diff-3aed1db56883460f31ad9365dcdec9149bd7f84882116e6d0329186ba960c9d9L160-R208) [[2]](diffhunk://#diff-3aed1db56883460f31ad9365dcdec9149bd7f84882116e6d0329186ba960c9d9L175-R235)
* Wrapped the post update and delete queries in try-catch blocks to handle database exceptions and return an internal server error with a detailed message (`controllers/post.cpp`). [[1]](diffhunk://#diff-3aed1db56883460f31ad9365dcdec9149bd7f84882116e6d0329186ba960c9d9R307-R320) [[2]](diffhunk://#diff-3aed1db56883460f31ad9365dcdec9149bd7f84882116e6d0329186ba960c9d9R370-R383)